### PR TITLE
Feature/do-credit-operations

### DIFF
--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/business/CreditService.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/business/CreditService.java
@@ -1,8 +1,11 @@
 package com.nttdata.bootcamp.activeoperationsservice.business;
 
 import com.nttdata.bootcamp.activeoperationsservice.model.Credit;
+import com.nttdata.bootcamp.activeoperationsservice.model.Operation;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditCreateRequestDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditUpdateRequestDTO;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditConsumeCreditRequestDTO;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CreditFindBalancesResponseDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CustomerCustomerServiceResponseDTO;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -15,4 +18,9 @@ public interface CreditService {
     Mono<Credit> removeById(String id);
     Mono<CustomerCustomerServiceResponseDTO> findByIdCustomerService(String id);
     Flux<Credit> findByCustomerId(String id);
+    Mono<Credit> consumeCredit(CreditConsumeCreditRequestDTO creditDTO);
+    Mono<Credit> payCredit(String billingOrderId);
+    Mono<Credit> generateBillingOrder(String creditId);
+    Flux<Operation> findOperationsByCreditId(String id);
+    Flux<CreditFindBalancesResponseDTO> findBalancesByCustomerId(String id);
 }

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/config/Constants.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/config/Constants.java
@@ -21,4 +21,16 @@ public class Constants {
 
     @Value("${constants.status.active}")
     private String STATUS_ACTIVE;
+
+    @Value("${constants.operation.consumption_type}")
+    private String OPERATION_CONSUMPTION_TYPE;
+
+    @Value("${constants.operation.payment_type}")
+    private String OPERATION_PAYMENT_TYPE;
+
+    @Value("${constants.billing_order.paid_status}")
+    private String BILLING_ORDER_PAID;
+
+    @Value("${constants.billing_order.unpaid_status}")
+    private String BILLING_ORDER_UNPAID;
 }

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/BillingOrder.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/BillingOrder.java
@@ -9,7 +9,9 @@ import lombok.*;
 @Builder
 @ToString
 public class BillingOrder {
-    public Double calculatedAmount;
-    public String cycle;
-    public String status;
+    private String id;
+    private Double calculatedAmount;
+    private Double amountToRefund;
+    private String cycle;
+    private String status;
 }

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/Operation.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/Operation.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @Builder
 @ToString
 public class Operation {
-    private String operationNumber = UUID.randomUUID().toString();
+    private String operationNumber;
     private Date time;
     private String type;
     private Double amount;

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/request/CreditConsumeCreditRequestDTO.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/request/CreditConsumeCreditRequestDTO.java
@@ -1,0 +1,14 @@
+package com.nttdata.bootcamp.activeoperationsservice.model.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CreditConsumeCreditRequestDTO {
+    private String id;
+    private Double amount;
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/request/CreditPayCreditRequestDTO.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/request/CreditPayCreditRequestDTO.java
@@ -1,0 +1,4 @@
+package com.nttdata.bootcamp.activeoperationsservice.model.dto.request;
+
+public class CreditPayCreditRequestDTO {
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CreditFindBalancesResponseDTO.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CreditFindBalancesResponseDTO.java
@@ -1,0 +1,15 @@
+package com.nttdata.bootcamp.activeoperationsservice.model.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CreditFindBalancesResponseDTO {
+    private String id;
+    private Double fullGrantedAmount;
+    private Double availableAmount;
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/repository/CreditRepository.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/repository/CreditRepository.java
@@ -1,9 +1,11 @@
 package com.nttdata.bootcamp.activeoperationsservice.repository;
 
 import com.nttdata.bootcamp.activeoperationsservice.model.Credit;
+import org.reactivestreams.Publisher;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 @Repository
 public interface CreditRepository extends ReactiveMongoRepository<Credit, String> {

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/BillingOrderUtils.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/BillingOrderUtils.java
@@ -1,0 +1,6 @@
+package com.nttdata.bootcamp.activeoperationsservice.utils;
+
+public interface BillingOrderUtils {
+    Double roundDouble(Double numberToRound, int decimalPlaces);
+    Double applyInterests(Double number, Double interestPercentage);
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/CreditUtils.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/CreditUtils.java
@@ -1,13 +1,18 @@
 package com.nttdata.bootcamp.activeoperationsservice.utils;
 
 import com.nttdata.bootcamp.activeoperationsservice.model.Credit;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditConsumeCreditRequestDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditCreateRequestDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditUpdateRequestDTO;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CreditFindBalancesResponseDTO;
 
 public interface CreditUtils {
     Credit creditCreateRequestDTOToCredit(CreditCreateRequestDTO creditDTO);
     Credit creditUpdateRequestDTOToCredit(CreditUpdateRequestDTO creditDTO);
+    Credit creditFindBalancesResponseDTOToCredit(CreditFindBalancesResponseDTO creditDTO);
     CreditCreateRequestDTO creditToCreditCreateRequestDTO(Credit credit);
     CreditUpdateRequestDTO creditToCreditUpdateCreateRequestDTO(Credit credit);
+    CreditFindBalancesResponseDTO creditToCreditFindBalancesResponseDTO(Credit credit);
     Credit fillCreditWithCreditUpdateRequestDTO(Credit credit, CreditUpdateRequestDTO creditDTO);
+    Credit fillCreditWithCreditConsumeCreditRequestDTO(Credit credit, CreditConsumeCreditRequestDTO creditDTO);
 }

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/BillingOrderUtilsImpl.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/BillingOrderUtilsImpl.java
@@ -1,0 +1,23 @@
+package com.nttdata.bootcamp.activeoperationsservice.utils.impl;
+
+import com.nttdata.bootcamp.activeoperationsservice.utils.BillingOrderUtils;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BillingOrderUtilsImpl implements BillingOrderUtils {
+    @Override
+    public Double roundDouble(Double numberToRound, int decimalPlaces) {
+        numberToRound = numberToRound * Math.pow(10, decimalPlaces);
+        numberToRound = (double) (Math.round(numberToRound));
+        return numberToRound / Math.pow(10, decimalPlaces);
+    }
+
+    @Override
+    public Double applyInterests(Double amount, Double interestPercentage) {
+        return (100 + interestPercentage)/100 * amount;
+    }
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CreditUtilsImpl.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CreditUtilsImpl.java
@@ -1,20 +1,28 @@
 package com.nttdata.bootcamp.activeoperationsservice.utils.impl;
 
+import com.nttdata.bootcamp.activeoperationsservice.config.Constants;
 import com.nttdata.bootcamp.activeoperationsservice.model.Credit;
 import com.nttdata.bootcamp.activeoperationsservice.model.Customer;
+import com.nttdata.bootcamp.activeoperationsservice.model.Operation;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditConsumeCreditRequestDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditCreateRequestDTO;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.request.CreditUpdateRequestDTO;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CreditFindBalancesResponseDTO;
 import com.nttdata.bootcamp.activeoperationsservice.utils.CreditUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class CreditUtilsImpl implements CreditUtils {
+    private final Constants constants;
+
     @Override
     public Credit creditCreateRequestDTOToCredit(CreditCreateRequestDTO creditDTO) {
         return Credit.builder()
@@ -37,6 +45,15 @@ public class CreditUtilsImpl implements CreditUtils {
                 .dueDate(creditDTO.getDueDate())
                 .operations(creditDTO.getOperations())
                 .billingDetails(creditDTO.getBillingDetails())
+                .build();
+    }
+
+    @Override
+    public Credit creditFindBalancesResponseDTOToCredit(CreditFindBalancesResponseDTO creditDTO) {
+        return Credit.builder()
+                .id(creditDTO.getId())
+                .fullGrantedAmount(creditDTO.getFullGrantedAmount())
+                .availableAmount(creditDTO.getAvailableAmount())
                 .build();
     }
 
@@ -66,6 +83,15 @@ public class CreditUtilsImpl implements CreditUtils {
     }
 
     @Override
+    public CreditFindBalancesResponseDTO creditToCreditFindBalancesResponseDTO(Credit credit) {
+        return CreditFindBalancesResponseDTO.builder()
+                .id(credit.getId())
+                .fullGrantedAmount(credit.getFullGrantedAmount())
+                .availableAmount(credit.getAvailableAmount())
+                .build();
+    }
+
+    @Override
     public Credit fillCreditWithCreditUpdateRequestDTO(Credit credit, CreditUpdateRequestDTO creditDTO) {
         credit.setId(creditDTO.getId());
         credit.setStatus(creditDTO.getStatus());
@@ -74,6 +100,24 @@ public class CreditUtilsImpl implements CreditUtils {
         credit.setDueDate(creditDTO.getDueDate());
         credit.setOperations(creditDTO.getOperations());
         credit.setBillingDetails(creditDTO.getBillingDetails());
+        return credit;
+    }
+
+    @Override
+    public Credit fillCreditWithCreditConsumeCreditRequestDTO(Credit credit, CreditConsumeCreditRequestDTO creditDTO) {
+        Operation operation = Operation.builder()
+                .amount(creditDTO.getAmount())
+                .time(new Date())
+                .type(constants.getOPERATION_CONSUMPTION_TYPE())
+                .operationNumber(UUID.randomUUID().toString())
+                .build();
+
+        ArrayList<Operation> operations = credit.getOperations() == null ? new ArrayList<>() : credit.getOperations();
+        operations.add(operation);
+
+        credit.setOperations(operations);
+        credit.setId(creditDTO.getId());
+
         return credit;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,9 @@ constants:
   status:
     blocked: Blocked
     active: Active
+  billing_order:
+    paid_status: Paid
+    unpaid_status: Unpaid
   customer:
     personal_type: Personal
     business_type: Business


### PR DESCRIPTION
Implemented functions for the following use cases:

- **ConsumeCredit:" Added endpoint to consume credit of a product taking in consideration the following points:
  - Can not consume credit from a blocked product.
  - The consumption amount can be greater than the available amount.
- **GenerateBillingOrder:** Added endpoint to randomly generate a billing order for an specified credit product, for testing purposes. This functionality takes in consideration the following points:
  - The amount of the billing order is calculated based on the credit consumptions, which is the difference between the full granted ammount and the available amount. If that difference is equal to zero, then there can not be generated a billing order.
- **PayCredit:* Added endpoint to pay a specified billing order.
- **FindOperationsByCreditId:** Added endpoint to retrieve the operations history of an specified credit.
- **FindBalancesByCustomerId:** Added endpoint to retrieve the balances of all the credit products from an specified customer.