### PR TITLE
Feature/add-customer-groups

### DIFF
--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/business/impl/CreditServiceImpl.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/business/impl/CreditServiceImpl.java
@@ -339,7 +339,7 @@ public class CreditServiceImpl implements CreditService {
             return Mono.error(new IllegalArgumentException("Credit does not billing details"));
         }
 
-        if (customerFromMicroservice.getType().contentEquals(constants.getCUSTOMER_PERSONAL_TYPE()))
+        if (customerFromMicroservice.getCustomerType().getGroup().contentEquals(constants.getCUSTOMER_PERSONAL_GROUP()))
         {
             return findByCustomerId(customerFromMicroservice.getId())
                     .filter(retrievedAccount -> retrievedAccount.getStatus().contentEquals(constants.getSTATUS_ACTIVE()))

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/config/Constants.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/config/Constants.java
@@ -13,11 +13,11 @@ public class Constants {
     @Value("${constants.eureka.service_url.gateway_service}")
     private String GATEWAY_SERVICE_URL;
 
-    @Value("${constants.customer.personal_type}")
-    private String CUSTOMER_PERSONAL_TYPE;
+    @Value("${constants.customer.personal_group}")
+    private String CUSTOMER_PERSONAL_GROUP;
 
-    @Value("${constants.customer.business_type}")
-    private String CUSTOMER_BUSINESS_TYPE;
+    @Value("${constants.customer.business_group}")
+    private String CUSTOMER_BUSINESS_GROUP;
 
     @Value("${constants.status.blocked}")
     private String STATUS_BLOCKED;

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/CustomerType.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/CustomerType.java
@@ -8,8 +8,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 @ToString
-public class Customer {
-    private String id;
-    private CustomerType customerType;
-    private String status;
+public class CustomerType {
+    private String group;
+    private String subgroup;
 }

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CustomerCustomerServiceResponseDTO.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CustomerCustomerServiceResponseDTO.java
@@ -10,7 +10,7 @@ import lombok.*;
 @ToString
 public class CustomerCustomerServiceResponseDTO {
     private String id;
-    private String type;
+    private CustomerTypeCustomerServiceResponseDTO customerType;
     private String status;
     private PersonDetailsCustomerServiceResponseDTO personDetails;
     private BusinessDetailsCustomerServiceResponseDTO businessDetails;

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CustomerTypeCustomerServiceResponseDTO.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/model/dto/response/CustomerTypeCustomerServiceResponseDTO.java
@@ -1,0 +1,14 @@
+package com.nttdata.bootcamp.activeoperationsservice.model.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class CustomerTypeCustomerServiceResponseDTO {
+    private String group;
+    private String subgroup;
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/CustomerTypeUtils.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/CustomerTypeUtils.java
@@ -1,0 +1,9 @@
+package com.nttdata.bootcamp.activeoperationsservice.utils;
+
+import com.nttdata.bootcamp.activeoperationsservice.model.CustomerType;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CustomerTypeCustomerServiceResponseDTO;
+
+public interface CustomerTypeUtils {
+    CustomerTypeCustomerServiceResponseDTO customerTypeToCustomerTypeCustomerServiceResponseDTO(CustomerType customerType);
+    CustomerType customerTypeCustomerServiceResponseDTOToCustomerType(CustomerTypeCustomerServiceResponseDTO customerTypeDTO);
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CustomerTypeUtilsImpl.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CustomerTypeUtilsImpl.java
@@ -1,0 +1,25 @@
+package com.nttdata.bootcamp.activeoperationsservice.utils.impl;
+
+import com.nttdata.bootcamp.activeoperationsservice.model.CustomerType;
+import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CustomerTypeCustomerServiceResponseDTO;
+import com.nttdata.bootcamp.activeoperationsservice.utils.CustomerTypeUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomerTypeUtilsImpl implements CustomerTypeUtils {
+    @Override
+    public CustomerTypeCustomerServiceResponseDTO customerTypeToCustomerTypeCustomerServiceResponseDTO(CustomerType customerType) {
+        return CustomerTypeCustomerServiceResponseDTO.builder()
+                .group(customerType.getGroup())
+                .subgroup(customerType.getSubgroup())
+                .build();
+    }
+
+    @Override
+    public CustomerType customerTypeCustomerServiceResponseDTOToCustomerType(CustomerTypeCustomerServiceResponseDTO customerTypeDTO) {
+        return CustomerType.builder()
+                .group(customerTypeDTO.getGroup())
+                .subgroup(customerTypeDTO.getSubgroup())
+                .build();
+    }
+}

--- a/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CustomerUtilsImpl.java
+++ b/src/main/java/com/nttdata/bootcamp/activeoperationsservice/utils/impl/CustomerUtilsImpl.java
@@ -2,17 +2,22 @@ package com.nttdata.bootcamp.activeoperationsservice.utils.impl;
 
 import com.nttdata.bootcamp.activeoperationsservice.model.Customer;
 import com.nttdata.bootcamp.activeoperationsservice.model.dto.response.CustomerCustomerServiceResponseDTO;
+import com.nttdata.bootcamp.activeoperationsservice.utils.CustomerTypeUtils;
 import com.nttdata.bootcamp.activeoperationsservice.utils.CustomerUtils;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class CustomerUtilsImpl implements CustomerUtils {
+    private final CustomerTypeUtils customerTypeUtils;
+
     public Customer customerCustomerServiceDTOToCustomer(CustomerCustomerServiceResponseDTO customerDTO) {
         return Customer.builder()
                 .id(customerDTO.getId())
-                .type(customerDTO.getType())
+                .customerType(customerTypeUtils.customerTypeCustomerServiceResponseDTOToCustomerType(customerDTO.getCustomerType()))
                 .status(customerDTO.getStatus())
                 .build();
     }
@@ -20,7 +25,7 @@ public class CustomerUtilsImpl implements CustomerUtils {
     public CustomerCustomerServiceResponseDTO customerToCustomerCustomerServiceResponseDTO(Customer customer) {
         return CustomerCustomerServiceResponseDTO.builder()
                 .id(customer.getId())
-                .type(customer.getType())
+                .customerType(customerTypeUtils.customerTypeToCustomerTypeCustomerServiceResponseDTO(customer.getCustomerType()))
                 .status(customer.getStatus())
                 .build();
     }


### PR DESCRIPTION
Implemented support for customer-info-service's group and subgroups. Customers now can belong to two groups:

- **Personal:** For personal customers, the can belong to two subgroups:
  - Standard
  - VIP
- **Business:** For business customers, the can belong to two subgroups:
  - Standard
  - PYME